### PR TITLE
Updated for Composer 2 compatibility.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=5.6.0",
-        "composer-plugin-api": "^1.1"
+        "composer-plugin-api": "^1.1 || ^2.0"
     },
     "require-dev": {
         "composer/composer": "^1.6",

--- a/src/ComposerVersionRequirement.php
+++ b/src/ComposerVersionRequirement.php
@@ -38,6 +38,18 @@ class ComposerVersionRequirement implements PluginInterface, EventSubscriberInte
   /**
    * {@inheritdoc}
    */
+  public function deactivate(Composer $composer, IOInterface $io) {
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function uninstall(Composer $composer, IOInterface $io) {
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public static function getSubscribedEvents() {
     return [
       ScriptEvents::PRE_INSTALL_CMD => 'checkComposerVersion',


### PR DESCRIPTION
* Update composer-plugin-api requirements for Composer2.
* Add new methods added to PluginInterface.

Closes https://github.com/deviantintegral/composer-gavel/issues/6