### PR TITLE
Fix using wrong Locker parameters for composer 2.0+ #8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,6 +80,7 @@ test_and_cover: &test_and_cover
       - run: |
           [ -f /usr/local/lib/php/extensions/no-debug-non-zts-20170718/xdebug.so ] || pecl install xdebug
           echo 'zend_extension=/usr/local/lib/php/extensions/no-debug-non-zts-20170718/xdebug.so' > /usr/local/etc/php/conf.d/xdebug.ini
+          echo 'xdebug.mode="coverage"' >> /usr/local/etc/php/conf.d/xdebug.ini
 
       - save_cache:
           paths:

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "composer-plugin-api": "^1.1 || ^2.0"
     },
     "require-dev": {
-        "composer/composer": "^1.6",
+        "composer/composer": "^1.6 || ^2.0",
         "phpunit/phpunit": "5 - 7",
         "mikey179/vfsstream": "^1.6"
     },

--- a/src/ComposerVersionRequirement.php
+++ b/src/ComposerVersionRequirement.php
@@ -125,7 +125,14 @@ class ComposerVersionRequirement implements PluginInterface, EventSubscriberInte
     $lockFile = "json" === pathinfo($file, PATHINFO_EXTENSION)
       ? substr($file, 0, -4).'lock'
       : $file . '.lock';
-    $locker = new Locker($this->io, new JsonFile($lockFile, null, $this->io), $this->composer->getRepositoryManager(), $this->composer->getInstallationManager(), $contents);
+
+    if (substr(PluginInterface::PLUGIN_API_VERSION, 0) == '1') {
+      $locker = new Locker($this->io, new JsonFile($lockFile, null, $this->io), $this->composer->getRepositoryManager(), $this->composer->getInstallationManager(), $contents);
+    }
+    else {
+      $locker = new Locker($this->io, new JsonFile($lockFile, null, $this->io), $this->composer->getInstallationManager(), $contents);
+    }
+
     $this->composer->setLocker($locker);
 
     $this->io->writeError(sprintf('<info>Composer requirement set to %s.</info>', $constraint));

--- a/tests/ComposerVersionRequirementTest.php
+++ b/tests/ComposerVersionRequirementTest.php
@@ -173,11 +173,11 @@ class ComposerVersionRequirementTest extends TestCase {
     $composer->method('getPackage')->willReturn($package);
 
     // This matches the constraint in require-dev in composer.json.
-    $package->method('getExtra')->willReturn(['composer-version' => '^1.6.3']);
+    $package->method('getExtra')->willReturn(['composer-version' => '^2.0']);
 
     /** @var \PHPUnit\Framework\MockObject\MockObject|\Composer\IO\IOInterface $io */
     $io = $this->getMockBuilder(IOInterface::class)->getMock();
-    $io->expects($this->once())->method('writeError')->with('<info>Composer ' . $composer::VERSION . ' satisfies composer-version ^1.6.3.</info>');
+    $io->expects($this->once())->method('writeError')->with('<info>Composer ' . $composer::VERSION . ' satisfies composer-version ^2.0.</info>');
 
     $vr = new ComposerVersionRequirement();
     $vr->activate($composer, $io);
@@ -197,9 +197,7 @@ class ComposerVersionRequirementTest extends TestCase {
     $package = $this->getMockBuilder(RootPackageInterface::class)->getMock();
     $composer->method('getPackage')->willReturn($package);
 
-    // It is safe to test against Composer 2 as our dev dependency locks us to
-    // Composer 1.
-    $package->method('getExtra')->willReturn(['composer-version' => '^2.0.0']);
+    $package->method('getExtra')->willReturn(['composer-version' => '^2.9.9']);
 
     /** @var \PHPUnit\Framework\MockObject\MockObject|\Composer\IO\IOInterface $io */
     $io = $this->getMockBuilder(IOInterface::class)->getMock();
@@ -209,7 +207,7 @@ class ComposerVersionRequirementTest extends TestCase {
 
     $event = new Event(ScriptEvents::PRE_INSTALL_CMD, $composer, $io);
     $this->expectException(ConstraintException::class);
-    $this->expectExceptionMessage('Composer ' . $composer::VERSION . ' is in use but this project requires Composer ^2.0.0. Upgrade composer by running composer self-update.');
+    $this->expectExceptionMessage('Composer ' . $composer::VERSION . ' is in use but this project requires Composer ^2.9.9. Upgrade composer by running composer self-update.');
     $vr->checkComposerVersion($event);
   }
 


### PR DESCRIPTION
This fixes passing in the wrong locker parameters when the composer version is not already set in a project.

I haven't added tests against composer 1.x. Currently builds, pull in the latest composer version, which is good for ensuring there's no lurking regressions, but we should add a job that uses the latest 1.x release. Since we also need to clean up unsupported PHP versions and add PHP 7.4, I'm going to do that as a separate PR.