### PR TITLE
Add tests for composer 1 and update PHP versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,7 @@ test: &test
           fi
 
           php composer-setup.php --$COMPOSER_VERSION --quiet --install-dir /usr/local/bin --filename composer
+          composer --version
 
       - run: composer install -n --prefer-dist
 
@@ -74,6 +75,7 @@ test_and_cover: &test_and_cover
           fi
 
           php composer-setup.php --$COMPOSER_VERSION --quiet --install-dir /usr/local/bin --filename composer
+          composer --version
 
       - run: composer install -n --prefer-dist
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,8 +78,8 @@ test_and_cover: &test_and_cover
       - run: composer install -n --prefer-dist
 
       - run: |
-          [ -f /usr/local/lib/php/extensions/no-debug-non-zts-20170718/xdebug.so ] || pecl install xdebug
-          echo 'zend_extension=/usr/local/lib/php/extensions/no-debug-non-zts-20170718/xdebug.so' > /usr/local/etc/php/conf.d/xdebug.ini
+          [ -f /usr/local/lib/php/extensions/no-debug-non-zts-20200930/xdebug.so ] || pecl install xdebug
+          echo 'zend_extension=/usr/local/lib/php/extensions/no-debug-non-zts-20200930/xdebug.so' > /usr/local/etc/php/conf.d/xdebug.ini
           echo 'xdebug.mode="coverage"' >> /usr/local/etc/php/conf.d/xdebug.ini
 
       - save_cache:
@@ -111,37 +111,23 @@ test_and_cover: &test_and_cover
 jobs:
   build:
     docker:
-      # specify the version you desire here
-      - image: php:7.2
-
-      # Specify service dependencies here if necessary
-      # CircleCI maintains a library of pre-built images
-      # documented at https://circleci.com/docs/2.0/circleci-images/
-      # - image: circleci/mysql:9.4
+      - image: php:8.0
 
     working_directory: ~/repo
 
     <<: *test_and_cover
 
-  build_php56:
+  build_php73:
     docker:
-      - image: php:5.6
+      - image: php:7.3
 
     working_directory: ~/repo
 
     <<: *test
 
-  build_php70:
+  build_php74:
     docker:
-      - image: php:7.0
-
-    working_directory: ~/repo
-
-    <<: *test
-
-  build_php71:
-    docker:
-      - image: php:7.1
+      - image: php:7.4
 
     working_directory: ~/repo
 
@@ -154,6 +140,5 @@ workflows:
   test_cover_workflow:
     jobs:
       - build
-      - build_php56
-      - build_php70
-      - build_php71
+      - build_php73
+      - build_php74

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,6 +80,7 @@ test_and_cover: &test_and_cover
       - run: |
           [ -f /usr/local/lib/php/extensions/no-debug-non-zts-20170718/xdebug.so ] || pecl install xdebug
           echo 'zend_extension=/usr/local/lib/php/extensions/no-debug-non-zts-20170718/xdebug.so' > /usr/local/etc/php/conf.d/xdebug.ini
+          echo 'xdebug.mode="coverage"' >> /usr/local/etc/php/conf.d/xdebug.ini
 
       - save_cache:
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ test: &test
               exit 1
           fi
 
-          php composer-setup.php --quiet --install-dir /usr/local/bin --filename composer
+          php composer-setup.php --$COMPOSER_VERSION --quiet --install-dir /usr/local/bin --filename composer
 
       - run: composer install -n --prefer-dist
 
@@ -73,7 +73,7 @@ test_and_cover: &test_and_cover
               exit 1
           fi
 
-          php composer-setup.php --quiet --install-dir /usr/local/bin --filename composer
+          php composer-setup.php --$COMPOSER_VERSION --quiet --install-dir /usr/local/bin --filename composer
 
       - run: composer install -n --prefer-dist
 
@@ -114,6 +114,8 @@ jobs:
       - image: php:8.0
 
     working_directory: ~/repo
+    environment:
+      COMPOSER_VERSION: 2
 
     <<: *test_and_cover
 
@@ -122,6 +124,8 @@ jobs:
       - image: php:7.3
 
     working_directory: ~/repo
+    environment:
+      COMPOSER_VERSION: 2
 
     <<: *test
 
@@ -130,7 +134,19 @@ jobs:
       - image: php:7.4
 
     working_directory: ~/repo
+    environment:
+      COMPOSER_VERSION: 2
 
+    <<: *test
+
+  build_php74_composer_1:
+    docker:
+      - image: php:7.4
+
+    working_directory: ~/repo
+
+    environment:
+      COMPOSER_VERSION: 1
     <<: *test
 
 workflows:
@@ -142,3 +158,4 @@ workflows:
       - build
       - build_php73
       - build_php74
+      - build_php74_composer_1

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /vendor/
 composer.lock
 build
+.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": ">=5.6.0",
+        "php": ">=7.3",
         "composer-plugin-api": "^1.1 || ^2.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "composer-plugin-api": "^1.1 || ^2.0"
     },
     "require-dev": {
-        "composer/composer": "^1.6",
+        "composer/composer": "^1.6 || ^2.0",
         "phpunit/phpunit": "5 - 7",
         "mikey179/vfsstream": "^1.6"
     },

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     },
     "require-dev": {
         "composer/composer": "^1.6 || ^2.0",
-        "phpunit/phpunit": "5 - 7",
+        "phpunit/phpunit": "^9",
         "mikey179/vfsstream": "^1.6"
     },
     "autoload": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,25 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
-         bootstrap="vendor/autoload.php"
-         colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false">
-    <testsuites>
-        <testsuite name="Unit">
-            <directory suffix="Test.php">./tests</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">./src</directory>
-        </whitelist>
-    </filter>
-    <logging>
-      <log type="junit" target="build/logs/results.xml"/>
-      <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" backupStaticAttributes="false" bootstrap="vendor/autoload.php" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage processUncoveredFiles="true">
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="Unit">
+      <directory suffix="Test.php">./tests</directory>
+    </testsuite>
+  </testsuites>
+  <logging>
+    <junit outputFile="build/logs/results.xml"/>
+  </logging>
 </phpunit>

--- a/src/ComposerVersionRequirement.php
+++ b/src/ComposerVersionRequirement.php
@@ -125,7 +125,14 @@ class ComposerVersionRequirement implements PluginInterface, EventSubscriberInte
     $lockFile = "json" === pathinfo($file, PATHINFO_EXTENSION)
       ? substr($file, 0, -4).'lock'
       : $file . '.lock';
-    $locker = new Locker($this->io, new JsonFile($lockFile, null, $this->io), $this->composer->getRepositoryManager(), $this->composer->getInstallationManager(), $contents);
+
+    if (substr(PluginInterface::PLUGIN_API_VERSION, 0) == '1') {
+      $locker = new Locker($this->io, new JsonFile($lockFile, null, $this->io), $this->composer->getRepositoryManager(), $this->composer->getInstallationManager(), $contents);
+    }
+    else {
+      $locker = new Locker($this->io, new JsonFile($lockFile, null, $this->io), $this->composer->getInstallationManager(), $contents);
+    }
+
     $this->composer->setLocker($locker);
 
     $this->io->writeError(sprintf('<info>Composer requirement set to %s.</info>', $constraint));

--- a/tests/ComposerVersionRequirementTest.php
+++ b/tests/ComposerVersionRequirementTest.php
@@ -30,7 +30,7 @@ class ComposerVersionRequirementTest extends TestCase {
   /**
    * {@inheritdoc}
    */
-  protected function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     // Not all tests require this, but we want to ensure we never accidentally
@@ -44,7 +44,7 @@ class ComposerVersionRequirementTest extends TestCase {
   /**
    * {@inheritdoc}
    */
-  protected function tearDown() {
+  protected function tearDown(): void {
     parent::tearDown();
     // Unset the COMPOSER variable.
     putenv('COMPOSER');

--- a/tests/ComposerVersionRequirementTest.php
+++ b/tests/ComposerVersionRequirementTest.php
@@ -173,11 +173,11 @@ class ComposerVersionRequirementTest extends TestCase {
     $composer->method('getPackage')->willReturn($package);
 
     // This matches the constraint in require-dev in composer.json.
-    $package->method('getExtra')->willReturn(['composer-version' => '^1.6.3']);
+    $package->method('getExtra')->willReturn(['composer-version' => '^2.0']);
 
     /** @var \PHPUnit\Framework\MockObject\MockObject|\Composer\IO\IOInterface $io */
     $io = $this->getMockBuilder(IOInterface::class)->getMock();
-    $io->expects($this->once())->method('writeError')->with('<info>Composer ' . $composer::VERSION . ' satisfies composer-version ^1.6.3.</info>');
+    $io->expects($this->once())->method('writeError')->with('<info>Composer ' . $composer::VERSION . ' satisfies composer-version ^2.0.</info>');
 
     $vr = new ComposerVersionRequirement();
     $vr->activate($composer, $io);
@@ -197,9 +197,7 @@ class ComposerVersionRequirementTest extends TestCase {
     $package = $this->getMockBuilder(RootPackageInterface::class)->getMock();
     $composer->method('getPackage')->willReturn($package);
 
-    // It is safe to test against Composer 2 as our dev dependency locks us to
-    // Composer 1.
-    $package->method('getExtra')->willReturn(['composer-version' => '^2.0.0']);
+    $package->method('getExtra')->willReturn(['composer-version' => '^2.9.9']);
 
     /** @var \PHPUnit\Framework\MockObject\MockObject|\Composer\IO\IOInterface $io */
     $io = $this->getMockBuilder(IOInterface::class)->getMock();
@@ -209,7 +207,7 @@ class ComposerVersionRequirementTest extends TestCase {
 
     $event = new Event(ScriptEvents::PRE_INSTALL_CMD, $composer, $io);
     $this->expectException(ConstraintException::class);
-    $this->expectExceptionMessage('Composer ' . $composer::VERSION . ' is in use but this project requires Composer ^2.0.0. Upgrade composer by running composer self-update.');
+    $this->expectExceptionMessage('Composer ' . $composer::VERSION . ' is in use but this project requires Composer ^2.9.9. Upgrade composer by running composer self-update.');
     $vr->checkComposerVersion($event);
   }
 


### PR DESCRIPTION
This PR depends on #9 and:

* Updates our minimum supported PHP version 7.3
* Adds tests for PHP 8
* Updates PHPUnit to match
* Adds a test for PHP 7.4 / composer 1. My assumption is anyone running on PHP 8 will have updated to Composer 2.