### PR TITLE
test: derive testConstraintFails constraint from running Composer version

### DIFF
--- a/tests/ComposerVersionRequirementTest.php
+++ b/tests/ComposerVersionRequirementTest.php
@@ -318,7 +318,12 @@ class ComposerVersionRequirementTest extends TestCase
         $package = $this->getMockBuilder(RootPackageInterface::class)->getMock();
         $composer->method('getPackage')->willReturn($package);
 
-        $package->method('getExtra')->willReturn(['composer-version' => '^2.9.9']);
+        // Derive the constraint from the running Composer version so the test
+        // never accidentally passes once Composer releases a newer version. A
+        // running version can never satisfy a "greater than itself" constraint.
+        $version = $composer::VERSION;
+        $constraint = '> '.$version;
+        $package->method('getExtra')->willReturn(['composer-version' => $constraint]);
 
         /** @var \PHPUnit\Framework\MockObject\MockObject&IOInterface $io */
         $io = $this->getMockBuilder(IOInterface::class)->getMock();
@@ -328,7 +333,7 @@ class ComposerVersionRequirementTest extends TestCase
 
         $event = new Event(ScriptEvents::PRE_INSTALL_CMD, $composer, $io);
         $this->expectException(ConstraintException::class);
-        $this->expectExceptionMessage('Composer '.$composer::VERSION.' is in use but this project requires Composer ^2.9.9. Upgrade composer by running composer self-update.');
+        $this->expectExceptionMessage('Composer '.$version.' is in use but this project requires Composer '.$constraint.'. Upgrade composer by running composer self-update.');
         $vr->checkComposerVersion($event);
     }
 


### PR DESCRIPTION
## Summary

Fixes the nightly job failures (e.g. [run 27110112548](https://github.com/deviantintegral/composer-gavel/actions/runs/27110112548)). This is a **brittle test in composer-gavel, not a regression in Composer**.

`ComposerVersionRequirementTest::testConstraintFails` hardcoded a `^2.9.9` `composer-version` constraint and expected the *running* Composer version to never satisfy it, so that `checkComposerVersion()` would throw a `ConstraintException`.

`^2.9.9` desugars to `>=2.9.9,<3.0.0`. Once Composer **2.10.0** shipped (now 2.10.1 in the lock), the running version falls *inside* that range, so the constraint is satisfied, no exception is thrown, and `expectException` fails. Verified directly:

```
Semver::satisfies("2.10.0", "^2.9.9")  => true
Semver::satisfies("2.9.0",  "^2.9.9")  => false
```

This is correct semver behaviour (`2.10.0 > 2.9.9`), not a Composer bug — the test simply assumed a version range that reality eventually reached.

## Fix

Derive the constraint from the running Composer version as `> <version>`, which the running version can never satisfy. The expectation no longer depends on a specific Composer release, removing the time-bomb.

## Testing

- `vendor/bin/phpunit` — all 19 tests pass (previously 1 failure across every PHP matrix entry).
- `php-cs-fixer` — clean.

https://claude.ai/code/session_01WbmgkgsqEjDdio6ehhpngr

---
_Generated by [Claude Code](https://claude.ai/code/session_01WbmgkgsqEjDdio6ehhpngr)_